### PR TITLE
removed trailing comma from function call

### DIFF
--- a/src/vconnector/core.py
+++ b/src/vconnector/core.py
@@ -156,7 +156,7 @@ class VConnector(object):
                 user=self.user,
                 pwd=self.pwd,
                 port=self.port,
-                sslContext=self.ssl_context,
+                sslContext=self.ssl_context
             )
         except Exception as e:
             # TODO: Maybe retry connection after some time


### PR DESCRIPTION
Removing trailing comma from function call. Was breaking in python 2.7.10 (possibly others).